### PR TITLE
Handle error cases.

### DIFF
--- a/src/urg_c_wrapper.cpp
+++ b/src/urg_c_wrapper.cpp
@@ -82,6 +82,15 @@ URGCWrapper::URGCWrapper(const int serial_baud, const std::string& serial_port, 
 
 void URGCWrapper::initialize(bool& using_intensity, bool& using_multiecho){
   int urg_data_size = urg_max_data_size(&urg_);
+  // urg_max_data_size can return a negative, error code value. Resizing based on this value will fail.
+  if (urg_data_size < 0) {
+    urg_.last_errno = urg_data_size;
+    std::stringstream ss;
+    ss << "Could not initialize Hokuyo:\n";
+    ss << urg_error(&urg_);
+    throw std::runtime_error(ss.str());
+  }
+
   if(urg_data_size  > 5000){  // Ocassionally urg_max_data_size returns a string pointer, make sure we don't allocate too much space, the current known max is 1440 steps
     urg_data_size = 5000;
   }

--- a/src/urg_c_wrapper.cpp
+++ b/src/urg_c_wrapper.cpp
@@ -74,6 +74,8 @@ URGCWrapper::URGCWrapper(const int serial_baud, const std::string& serial_port, 
     ss << "Could not open serial Hokuyo:\n";
     ss << serial_port << " @ " << serial_baud << "\n";
     ss << urg_error(&urg_);
+    stop();
+    urg_close(&urg_);
     throw std::runtime_error(ss.str());
   }
 
@@ -88,6 +90,8 @@ void URGCWrapper::initialize(bool& using_intensity, bool& using_multiecho){
     std::stringstream ss;
     ss << "Could not initialize Hokuyo:\n";
     ss << urg_error(&urg_);
+    stop();
+    urg_close(&urg_);
     throw std::runtime_error(ss.str());
   }
 

--- a/src/urg_node.cpp
+++ b/src/urg_node.cpp
@@ -246,8 +246,8 @@ int main(int argc, char **argv)
       ros::spinOnce();
       ros::Duration(1.0).sleep();
       continue; // Return to top of master loop
-    } catch(...){
-      ROS_ERROR_THROTTLE(10.0, "Unknown error connecting to Hokuyo");
+    } catch(std::exception& e){
+      ROS_ERROR_THROTTLE(10.0, "Unknown error connecting to Hokuyo: %s", e.what());
       ros::spinOnce();
       ros::Duration(1.0).sleep();
       continue; // Return to top of master loop


### PR DESCRIPTION
While we wait for ros-drivers/urg_node#22 to be merged upstream:
> If a lidar is disconnected during operation, URGCWrapper may throw during instantiation. This bypasses its destructor, so neither URGCWrapper::stop nor urg_close are called. URGCWrapper will always fail to connect after this point, due to the dangling connection.
> 
> This failure mode is not well-handled by urg_c_wrapper, so urg_open does not return an error result, even though urg_.is_active is false. urg_max_data_size returns URG_NOT_CONNECTED (-2) when !urg_.is_active, which URGCWrapper::initialize attempts to use to allocate its data and intensity buffers. This is not a std::runtime_error, so urg_node's mainloop swallows it as an unknown error.
> 
> Changes:
> - Mimic the destructor and disconnect from the laser before throwing exceptions during construction.
> - Check urg_max_data_size for error codes before attempting to allocate memory with its result.
> - Catch std::exception and log its message in urg_node's mainloop.

@locusrobotics/robot-software-team