### PR TITLE
Add guard for lockout state

### DIFF
--- a/include/uam/uam_driver_ros.h
+++ b/include/uam/uam_driver_ros.h
@@ -127,6 +127,18 @@ private:
         params_changed_ = false;
       }
     }
+
+    // Update status
+    updateStatus(reply.sensing_data);
+
+    if (reply.sensing_data.lockout_state)
+    {
+      // According to the documentation, when the sensor gets into lockout state
+      // it will keep sending pointcloud but the measurement values are not updated.
+      ROS_WARN_STREAM_THROTTLE(5.0, "Sensor is in lockout state, skipping scan readings!");
+      return;
+    }
+
     // Fill scan metadata and header
     sensor_msgs::LaserScan msg;
     msg.header.frame_id = params_.frame_id;
@@ -142,8 +154,6 @@ private:
 
     // Read the right fields
     fillScanMessageData(reply, range_offset, msg);
-    // Update status
-    updateStatus(reply.sensing_data);
     scan_publisher_.publish(msg);
   }
 


### PR DESCRIPTION
When the lidar gets into a lockout state, we cannot publish the incoming message as the range readings will not be updated. This PR addresses that.
![image](https://github.com/locusrobotics/urg_node/assets/77983813/4c0ea32b-cbfb-404c-9420-a8226d007d50)
