### PR TITLE
Bugfix: clear async read flag if we disconnect

### DIFF
--- a/include/uam/io/tcp_client.h
+++ b/include/uam/io/tcp_client.h
@@ -160,7 +160,6 @@ public:
     // in progress.
     asyncReadData();
     stopped_ = false;
-    stop_requested_ = false;
     return true;
   }
 
@@ -295,11 +294,6 @@ private:
    * @brief State of the async read task
    */
   std::atomic_bool stopped_;
-
-  /**
-   * @brief Request stop to the async read task
-   */
-  std::atomic_bool stop_requested_;
 };
 
 }  // namespace uam

--- a/src/uam/io/tcp_client.cpp
+++ b/src/uam/io/tcp_client.cpp
@@ -52,8 +52,7 @@ TcpClient::TcpClient(OnNewDataCallback callback) :
   io_service_(std::make_shared<boost::asio::io_service>()),
   socket_(*io_service_),
   callback_(callback),
-  stopped_(true),
-  stop_requested_(false)
+  stopped_(true)
 {
   // Add a fake task to the io_service to prevent it from exiting until desired
   io_work_ = std::make_unique<boost::asio::io_service::work>(*io_service_);
@@ -67,8 +66,7 @@ TcpClient::TcpClient(OnNewDataCallback callback, std::shared_ptr<boost::asio::io
   io_service_(external_context),
   socket_(*io_service_),
   callback_(callback),
-  stopped_(true),
-  stop_requested_(false)
+  stopped_(true)
 {
 }
 
@@ -95,6 +93,8 @@ void TcpClient::disconnect()
         ROS_WARN_STREAM("Failed to close socket. " << error_code.message());
       }
     }
+    // Clear async read flag
+    stopped_ = true;
   }
 }
 
@@ -160,7 +160,7 @@ bool TcpClient::connect(const std::string& remote_ip, uint16_t remote_port)
 
 void TcpClient::asyncReadData(const size_t packet_offset)
 {
-  if (!connected_ || stop_requested_)
+  if (!connected_)
   {
     stopped_ = true;
     return;


### PR DESCRIPTION
When the lidar disconnects, it would never successfully reconnect due to an internal flag.
```
Jun 23 12:41:33 v1-21315 locus[2463]: [ INFO] [/v1_21315/rear_laser_node]: Connected to: 10.66.171.9:10940
Jun 23 12:41:33 v1-21315 locus[2463]: [ INFO] [/v1_21315/rear_laser_node]: Actual receive buffer size: 131072 bytes
Jun 23 12:41:33 v1-21315 locus[2463]: [ INFO] [/v1_21315/rear_laser_node]: Connected to Uam lidar.
Jun 23 12:41:33 v1-21315 locus[2463]: [ERROR] [/v1_21315/rear_laser_node]: Error while configuring the lidar: Failed to get scan details. Client is running async read tasks! 
```