### PR TITLE
Rst 7779 uam command timeout issue

### DIFF
--- a/include/uam/io/tcp_client.h
+++ b/include/uam/io/tcp_client.h
@@ -132,7 +132,7 @@ public:
     if (status != std::future_status::ready)
     {
       // we are not expecting this to happen too often, no need to throttle this warning.
-      ROS_WARN_STREAM("Failed sending command " << command << " : " << status == std::future_status::timeout ? "timeout" : "deferred");
+      ROS_WARN_STREAM("Failed sending command " << command << " : " << (status == std::future_status::timeout ? "timeout" : "deferred"));
       return false;
     }
     return (send_length.get() == command.size());
@@ -219,12 +219,26 @@ private:
   void asyncReadData(const size_t packet_offset = 0);
 
   /**
-   * @brief Receive handler for Async read
+   * @brief Receive handler for initial async read
+   * 
+   * This will handle the initial packet filtering. Once we validated that
+   * the sequence of bytes might form a valid packet, we create a new async
+   * read task to get the reamining bytes.
    *
    * @param[in] error_code - Error Code
    * @param[in] bytes_transferred - Number of bytes written into the buffer
    */
   void handleReceive(const boost::system::error_code& error_code, size_t bytes_transferred);
+  
+  /**
+   * @brief Receive handler for Async read
+   *
+   * @param[in] error_code - Error Code
+   * @param[in] bytes_transferred - Number of bytes written into the buffer
+   * @param[in] missing_read - Missing read bytes to complete packet
+   * @param[in] stamp - Stamp from the packet header reception
+   */
+  void handlePacket(const boost::system::error_code& error_code, size_t bytes_transferred, const size_t missing_read, const ros::Time& stamp);
 
 private:
   /**

--- a/include/uam/io/tcp_client.h
+++ b/include/uam/io/tcp_client.h
@@ -132,7 +132,7 @@ public:
     if (status != std::future_status::ready)
     {
       // we are not expecting this to happen too often, no need to throttle this warning.
-      ROS_WARN_STREAM("Send command timed out...");
+      ROS_WARN_STREAM("Failed sending command " << command << " : " << status == std::future_status::timeout ? "timeout" : "deferred");
       return false;
     }
     return (send_length.get() == command.size());

--- a/include/uam/io/tcp_client.h
+++ b/include/uam/io/tcp_client.h
@@ -121,9 +121,7 @@ public:
    *
    * @return true if command successfully sent, false otherwise.
    */
-  inline bool asyncSend(
-    const std::string& command,
-    const std::chrono::seconds timeout = std::chrono::seconds(5))
+  inline bool asyncSend(const std::string& command, const std::chrono::seconds timeout = std::chrono::seconds(5))
   {
     if (!connected_)
       return false;
@@ -132,7 +130,9 @@ public:
     if (status != std::future_status::ready)
     {
       // we are not expecting this to happen too often, no need to throttle this warning.
-      ROS_WARN_STREAM("Failed sending command " << command << " : " << (status == std::future_status::timeout ? "timeout" : "deferred"));
+      ROS_WARN_STREAM(
+        "Failed sending command " << command << " : "
+                                  << (status == std::future_status::timeout ? "timeout" : "deferred"));
       return false;
     }
     return (send_length.get() == command.size());
@@ -201,7 +201,7 @@ public:
           line.clear();
         }
         handler(reply);
-      });  //NOLINT
+      });  // NOLINT
 
     return;
   }
@@ -220,7 +220,7 @@ private:
 
   /**
    * @brief Receive handler for initial async read
-   * 
+   *
    * This will handle the initial packet filtering. Once we validated that
    * the sequence of bytes might form a valid packet, we create a new async
    * read task to get the reamining bytes.
@@ -229,7 +229,7 @@ private:
    * @param[in] bytes_transferred - Number of bytes written into the buffer
    */
   void handleReceive(const boost::system::error_code& error_code, size_t bytes_transferred);
-  
+
   /**
    * @brief Receive handler for Async read
    *
@@ -238,7 +238,11 @@ private:
    * @param[in] missing_read - Missing read bytes to complete packet
    * @param[in] stamp - Stamp from the packet header reception
    */
-  void handlePacket(const boost::system::error_code& error_code, size_t bytes_transferred, const size_t missing_read, const ros::Time& stamp);
+  void handlePacket(
+    const boost::system::error_code& error_code,
+    size_t bytes_transferred,
+    const size_t missing_read,
+    const ros::Time& stamp);
 
 private:
   /**

--- a/include/uam/io/tcp_client.h
+++ b/include/uam/io/tcp_client.h
@@ -223,7 +223,7 @@ private:
    *
    * This will handle the initial packet filtering. Once we validated that
    * the sequence of bytes might form a valid packet, we create a new async
-   * read task to get the reamining bytes.
+   * read task to get the remaining bytes.
    *
    * @param[in] error_code - Error Code
    * @param[in] bytes_transferred - Number of bytes written into the buffer

--- a/src/uam/io/tcp_client.cpp
+++ b/src/uam/io/tcp_client.cpp
@@ -75,12 +75,12 @@ TcpClient::~TcpClient()
   this->disconnect();
   if (io_service_owner_)
   {
-	  io_work_.reset();
-	  // Wait for the io thread to terminate cleanly
-	  if (io_thread_.joinable())
-	  {
-	    io_thread_.join();
-	  }
+    io_work_.reset();
+    // Wait for the io thread to terminate cleanly
+    if (io_thread_.joinable())
+    {
+      io_thread_.join();
+    }
   }
 }
 
@@ -189,7 +189,11 @@ void TcpClient::asyncReadData(const size_t packet_offset)
       boost::asio::placeholders::bytes_transferred));
 }
 
-void TcpClient::handlePacket(const boost::system::error_code& error_code, size_t bytes_transferred,const size_t missing_read, const ros::Time& stamp)
+void TcpClient::handlePacket(
+  const boost::system::error_code& error_code,
+  size_t bytes_transferred,
+  const size_t missing_read,
+  const ros::Time& stamp)
 {
   if (error_code)
   {
@@ -250,7 +254,7 @@ void TcpClient::handleReceive(const boost::system::error_code& error_code, size_
 
       if (valid_expected_size)
       {
-    	// Add an async read task to read the rest of the packet
+        // Add an async read task to read the rest of the packet
         boost::system::error_code new_error_code;
         auto missing_read = expected_total_size - bytes_transferred;
         boost::asio::async_read(
@@ -262,7 +266,8 @@ void TcpClient::handleReceive(const boost::system::error_code& error_code, size_
             this,
             boost::asio::placeholders::error,
             boost::asio::placeholders::bytes_transferred,
-            missing_read, stamp));
+            missing_read,
+            stamp));
         return;
       }
       else

--- a/src/uam/io/tcp_client.cpp
+++ b/src/uam/io/tcp_client.cpp
@@ -191,17 +191,20 @@ void TcpClient::asyncReadData(const size_t packet_offset)
 
 void TcpClient::handlePacket(const boost::system::error_code& error_code, size_t bytes_transferred,const size_t missing_read, const ros::Time& stamp)
 {
-  if (!connected_)
+  if (error_code)
   {
-    stopped_ = true;
-    return;
+    // "operation_aborted" errors will occur if the socket is closed for any reason. Don't spam the logs with expected
+    // error conditions.
+    if (connected_ || error_code != boost::asio::error::operation_aborted)
+    {
+      ROS_ERROR_STREAM("Error receiving lidar message. " << error_code.message());
+    }
   }
-
-  if (error_code || bytes_transferred != missing_read)
+  else if (bytes_transferred != missing_read)
   {
     ROS_WARN_STREAM(
-      "Failed to read: " << error_code.message() << " Received " << bytes_transferred << "bytes\n"
-                         << "Expected " << missing_read << " bytes");
+      "Failed to read missing bytes. Received " << bytes_transferred << "bytes\n"
+                                                << "Expected " << missing_read << " bytes");
   }
   else
   {

--- a/src/uam/io/tcp_client.cpp
+++ b/src/uam/io/tcp_client.cpp
@@ -73,6 +73,15 @@ TcpClient::TcpClient(OnNewDataCallback callback, std::shared_ptr<boost::asio::io
 TcpClient::~TcpClient()
 {
   this->disconnect();
+  if (io_service_owner_)
+  {
+	  io_work_.reset();
+	  // Wait for the io thread to terminate cleanly
+	  if (io_thread_.joinable())
+	  {
+	    io_thread_.join();
+	  }
+  }
 }
 
 void TcpClient::disconnect()

--- a/src/uam/io/tcp_client.cpp
+++ b/src/uam/io/tcp_client.cpp
@@ -189,10 +189,31 @@ void TcpClient::asyncReadData(const size_t packet_offset)
       boost::asio::placeholders::bytes_transferred));
 }
 
+void TcpClient::handlePacket(const boost::system::error_code& error_code, size_t bytes_transferred,const size_t missing_read, const ros::Time& stamp)
+{
+  if (!connected_)
+  {
+    stopped_ = true;
+    return;
+  }
+
+  if (error_code || bytes_transferred != missing_read)
+  {
+    ROS_WARN_STREAM(
+      "Failed to read: " << error_code.message() << " Received " << bytes_transferred << "bytes\n"
+                         << "Expected " << missing_read << " bytes");
+  }
+  else
+  {
+    callback_(receive_buffer_, stamp);
+  }
+  // Resume async read
+  asyncReadData();
+}
+
 void TcpClient::handleReceive(const boost::system::error_code& error_code, size_t bytes_transferred)
 {
   // Grab a packet received time as soon as possible
-  auto received_stamp = ros::Time::now();
   size_t packet_offset = 0;
 
   if (error_code)
@@ -226,23 +247,20 @@ void TcpClient::handleReceive(const boost::system::error_code& error_code, size_
 
       if (valid_expected_size)
       {
+    	// Add an async read task to read the rest of the packet
         boost::system::error_code new_error_code;
         auto missing_read = expected_total_size - bytes_transferred;
-        auto recv_bytes = boost::asio::read(
+        boost::asio::async_read(
           socket_,
           boost::asio::buffer(receive_buffer_.getRawPacket().data() + bytes_transferred, missing_read),
           boost::asio::transfer_exactly(missing_read),
-          new_error_code);
-        if (new_error_code || recv_bytes != missing_read)
-        {
-          ROS_WARN_STREAM(
-            "Failed to read: " << new_error_code.message() << " Received " << recv_bytes << "bytes\n"
-                               << "Expected " << expected_total_size << " bytes");
-        }
-        else
-        {
-          callback_(receive_buffer_, stamp);
-        }
+          boost::bind(
+            &TcpClient::handlePacket,
+            this,
+            boost::asio::placeholders::error,
+            boost::asio::placeholders::bytes_transferred,
+            missing_read, stamp));
+        return;
       }
       else
       {
@@ -251,7 +269,7 @@ void TcpClient::handleReceive(const boost::system::error_code& error_code, size_
     }
     else
     {
-      ROS_WARN_STREAM("Packet was received but could not make sense of them, skipping it.");
+      ROS_WARN_STREAM("Packet was received but could not make sense of it, skipping it.");
     }
   }
   asyncReadData(packet_offset);


### PR DESCRIPTION
There is an issue with the uam driver that is preventing it from sending async commands to the lidar. As pointed out by @svwilliams, it is not advisable to mix async tasks with sync tasks, which may be the reason why the io context thread was getting stuck. 

Currently, this fix is being tested on the BST floor to fix the lidar problems of a bot that has been experiencing this issue once or twice every 2 to 3 hours.