### PR TITLE
Rst 7977 add safety areas visualization support to uam driver (#20)

### DIFF
--- a/include/uam/protocol_types/uam_protocol_types.h
+++ b/include/uam/protocol_types/uam_protocol_types.h
@@ -57,7 +57,7 @@ constexpr size_t c_nr_ranges_multiecho = 2161;
 /**
  * @brief Max safety area index for this the supported fw version
  */
-constexpr uint16_t c_max_safety_area_index = 32;
+constexpr uint32_t c_max_safety_area_index = 32;
 
 
 
@@ -718,7 +718,7 @@ struct YRCommandRequest
 struct YRCommandReply
 {
   YRCommandReplyHeader header;
-  std::array<uint32_t, 1080> area_data;
+  std::array<uint32_t, c_nr_ranges> area_data;
   CommandFooter footer;
 };
 #pragma pack()

--- a/include/uam/uam_driver_ros.h
+++ b/include/uam/uam_driver_ros.h
@@ -43,11 +43,16 @@
 #include <uam/uam_driver_ros_params.h>
 #include <urg_node/URGConfig.h>
 #include <uam/type_traits.h>
+#include <visualization_msgs/Marker.h>
 
 #include <atomic>
 #include <limits>
+#include <map>
 #include <mutex>
+#include <optional>
 #include <string>
+#include <utility>
+#include <vector>
 
 namespace uam
 {
@@ -58,6 +63,28 @@ class UamROS
    */
   template <typename T>
   using detected_intensities = decltype(T::intensities);
+
+  /**
+   * @brief Pair of CRC and safety area as laser scan
+   */
+  using ScanWithCRC = std::pair<uint32_t, sensor_msgs::LaserScan>;
+
+  /**
+   * @brief Safety Area Alias
+   */
+  using SafetyArea = std::map<uam::protocol::EYRAreaType, ScanWithCRC>;
+
+  /**
+   * @brief Laser Scan cached lookup, used to convert to cartesian coordiantes
+   */
+  struct LaserScanCachedLookup
+  {
+    float scan_angle_min { std::numeric_limits<float>::max() };
+    float scan_angle_max { std::numeric_limits<float>::lowest() };
+    float scan_angle_increment { std::numeric_limits<float>::lowest() };
+    std::vector<float> sin_lookup;
+    std::vector<float> cos_lookup;
+  };
 
 public:
   /**
@@ -190,6 +217,19 @@ private:
       // else is required by the if constexpr
     }
 
+    if (!safety_areas_.empty() && safety_markers_pub_.getNumSubscribers())
+    {
+      if (
+        safety_areas_.count(reply.sensing_data.area_number) &&
+        safety_areas_.at(reply.sensing_data.area_number).count(protocol::EYRAreaType::warning_2))
+      {
+        // Validate incoming ranges against the warning_2 area
+        publishWarningMarkers(
+          reply,
+          safety_areas_.at(reply.sensing_data.area_number).at(protocol::EYRAreaType::warning_2).second);
+      }
+    }
+
     scan_publisher_.publish(msg);
   }
 
@@ -220,6 +260,107 @@ private:
    */
   void updateStatus(const protocol::sensing_data::SensingDataHeader& sensing_data, const bool override_check = false);
 
+  /**
+   * @brief Advertise safety area type publishers
+   * @param[in] publishers - List of publishers to advertise
+   */
+  void advertiseSafetyAreaPublishers();
+
+  /**
+   * @brief Publish Safety Area scans
+   * @param[in] area_number - The lidar safety area number
+   */
+  void publishSafetyArea(const size_t area_number);
+
+  /**
+   * @brief Read Safety areas from lidar
+   */
+  void readSafetyAreas();
+
+  /**
+   * @brief Publish safety area violation markers
+   * @param[in] packet - Incoming packet
+   * @param[in] safety_area - Safety area to validate the ranges against
+   */
+  template <typename T>
+  void publishWarningMarkers(const T& packet, const sensor_msgs::LaserScan& safety_area)
+  {
+    auto getLut = [this](const ScanParameters& scan_params, const T& packet)
+    {
+      LaserScanCachedLookup lut;
+      lut.scan_angle_min = scan_params_.getAngleMinLimit();
+      lut.scan_angle_max = scan_params_.getAngleMaxLimit();
+      lut.scan_angle_increment = scan_params_.getAngleIncrement();
+
+      lut.sin_lookup.reserve(packet.ranges.size());
+      lut.cos_lookup.reserve(packet.ranges.size());
+
+      for (size_t i = 0; i < packet.ranges.size(); ++i)
+      {
+        const float angle = lut.scan_angle_min + static_cast<float>(i) * lut.scan_angle_increment;
+        lut.sin_lookup.emplace_back(::sinf(angle));
+        lut.cos_lookup.emplace_back(::cosf(angle));
+      }
+      return lut;
+    };
+
+    auto getRayMarker = [](const std::string& frame_id, const std::string& ns)
+    {
+      visualization_msgs::Marker marker;
+      marker.header.frame_id = frame_id;
+      marker.type = visualization_msgs::Marker::LINE_LIST;
+      marker.ns = ns;
+      marker.scale.x = 0.001;
+      marker.color.a = 1.0;
+      marker.color.r = 1.0;
+      return marker;
+    };
+
+    if (safety_area.ranges.size() != packet.ranges.size())
+      return;
+
+    // Cache the lookup
+    static auto cached_lookup = getLut(scan_params_, packet);
+    // Get marker
+    auto marker = getRayMarker(params_.frame_id, params_.frame_id);
+
+    for (size_t idx = 0; idx < safety_area.ranges.size(); ++idx)
+    {
+      auto& safety_range = safety_area.ranges[idx];
+      if (std::isnan(safety_range))
+      {
+        // No range for that ray
+        continue;
+      }
+      auto& raw_range = packet.ranges[idx];
+      if (raw_range != 0 && raw_range < 0xFFFC)
+      {
+        auto range = static_cast<float>(raw_range) / 1000.0f;
+        if (range <= safety_range)
+        {
+          geometry_msgs::Point pt;
+          pt.x = 0;
+          pt.y = 0;
+          marker.points.push_back(pt);
+          pt.x = static_cast<double>(range * cached_lookup.cos_lookup[idx]);
+          pt.y = static_cast<double>(range * cached_lookup.sin_lookup[idx]);
+          marker.points.push_back(pt);
+        }
+      }
+    }
+
+    if (!marker.points.empty())
+    {
+      marker.header.stamp = ros::Time::now();
+      marker.action = visualization_msgs::Marker::ADD;
+    }
+    else
+    {
+      marker.action = visualization_msgs::Marker::DELETE;
+    }
+    safety_markers_pub_.publish(marker);
+  }
+
 private:
   /**
    * \defgroup Lidar communication Section
@@ -240,6 +381,11 @@ private:
    * @brief Object to interface with the lidar
    */
   UamDriver lidar_;
+
+  /**
+   * @brief Lidar safety areas
+   */
+  std::map<size_t, SafetyArea> safety_areas_;
 
   /**@}*/
 
@@ -310,6 +456,16 @@ private:
    * @brief Configure Timer
    */
   ros::Timer configure_timer_;
+
+  /**
+   * @brief Safety Area publishers
+   */
+  std::array<ros::Publisher, uam::protocol::EYRAreaType::MAX> safety_area_publishers_;
+
+  /**
+   * @brief Safety area violation markers
+   */
+  ros::Publisher safety_markers_pub_;
 
   /**
    * @brief Dynamic reconfigure server

--- a/include/uam/uam_driver_ros_params.h
+++ b/include/uam/uam_driver_ros_params.h
@@ -85,6 +85,11 @@ public:
   unsigned int ip_port { 10940 };
 
   /**
+   * @brief Flag to log safety area CRC
+   */
+  bool log_safety_areas_crc { false };
+
+  /**
    * @brief The user defined maximum range of the lidar
    */
   double max_range { 40.0 };

--- a/src/uam/uam_driver.cpp
+++ b/src/uam/uam_driver.cpp
@@ -246,10 +246,8 @@ std::optional<protocol::YRCommandReply> UamDriver::getSafetyArea(
   const uint32_t end_step)
 {
   // TODO(cribeirmendes): Should we support async send?
-  if (isTheSensorStreaming())
-  {
-    this->stopStreaming();
-  }
+  if (client_.isStopped())
+    client_.startAsyncReadTask();
 
   const uint16_t adjusted_area_number = area_number == 0 ? area_number : area_number - 1;
   const uint32_t adjusted_start_step = start_step == 0 ? start_step : start_step - 1;

--- a/src/uam/uam_driver_ros.cpp
+++ b/src/uam/uam_driver_ros.cpp
@@ -44,6 +44,7 @@
 #include <limits>
 #include <mutex>
 #include <string>
+#include <utility>
 
 namespace uam
 {
@@ -67,6 +68,11 @@ UamROS::UamROS(const ros::NodeHandle& nh, const ros::NodeHandle& nh_prv, const U
 
   configure_timer_ =
     node_handle_.createTimer(params_.reconfiguration_timeout, &UamROS::configureTimerCallback, this, true, false);
+
+  safety_markers_pub_ = private_node_handle_.advertise<visualization_msgs::Marker>("safety_violation", 10);
+
+  // Advertise safety area publisher
+  advertiseSafetyAreaPublishers();
 
   // Clear the dynamic reconfigure server
   srv_.reset(new dynamic_reconfigure::Server<urg_node::URGConfig>(private_node_handle_));
@@ -97,6 +103,50 @@ UamROS::UamROS(const ros::NodeHandle& nh, const ros::NodeHandle& nh_prv, const U
   if (!configure())
   {
     configure_timer_.start();
+  }
+}
+
+void UamROS::advertiseSafetyAreaPublishers()
+{
+  safety_area_publishers_[protocol::EYRAreaType::protection_1] =
+    private_node_handle_.advertise<sensor_msgs::LaserScan>("safety_area/protection_1", 1, true);
+  safety_area_publishers_[protocol::EYRAreaType::protection_2] =
+    private_node_handle_.advertise<sensor_msgs::LaserScan>("safety_area/protection_2", 1, true);
+  safety_area_publishers_[protocol::EYRAreaType::warning_1] =
+    private_node_handle_.advertise<sensor_msgs::LaserScan>("safety_area/warning_1", 1, true);
+  safety_area_publishers_[protocol::EYRAreaType::warning_2] =
+    private_node_handle_.advertise<sensor_msgs::LaserScan>("safety_area/warning_2", 1, true);
+  safety_area_publishers_[protocol::EYRAreaType::muting_1] =
+    private_node_handle_.advertise<sensor_msgs::LaserScan>("safety_area/muting_1", 1, true);
+  safety_area_publishers_[protocol::EYRAreaType::muting_2] =
+    private_node_handle_.advertise<sensor_msgs::LaserScan>("safety_area/muting_2", 1, true);
+  safety_area_publishers_[protocol::EYRAreaType::reference_center] =
+    private_node_handle_.advertise<sensor_msgs::LaserScan>("safety_area/reference_center", 1, true);
+  safety_area_publishers_[protocol::EYRAreaType::reference_max] =
+    private_node_handle_.advertise<sensor_msgs::LaserScan>("safety_area/reference_max", 1, true);
+  safety_area_publishers_[protocol::EYRAreaType::reference_min] =
+    private_node_handle_.advertise<sensor_msgs::LaserScan>("safety_area/reference_min", 1, true);
+}
+
+void UamROS::publishSafetyArea(const size_t area_number)
+{
+  if (safety_areas_.empty())
+    return;
+  else if (!safety_areas_.count(area_number))
+  {
+    ROS_ERROR_STREAM("Cannot find requested area number in the database.");
+    return;
+  }
+
+  for (uint16_t area_type = static_cast<uint16_t>(protocol::EYRAreaType::protection_1);
+       area_type < static_cast<uint16_t>(uam::protocol::EYRAreaType::MAX);
+       area_type++)
+  {
+    auto message = safety_areas_.at(area_number).find(static_cast<protocol::EYRAreaType>(area_type));
+    if (message != safety_areas_.at(area_number).end())
+    {
+      safety_area_publishers_[static_cast<protocol::EYRAreaType>(area_type)].publish(message->second.second);
+    }
   }
 }
 
@@ -222,8 +272,14 @@ bool UamROS::configure()
     updateReconfigureLimits();
     auto version_details = lidar_.getVersionDetails();
     ROS_INFO_STREAM("Sensor details: " << version_details);
+
+    // Read laser safety areas
+    readSafetyAreas();
+
+    // Update laser status
     updateStatus(lidar_.getSensorStatus(), true);
 
+    // Start streaming
     lidar_.startStreaming(params_.use_intensity, params_.use_multi_echo);
     {
       std::lock_guard<std::mutex> lock(watchdog_mutex_);
@@ -298,13 +354,81 @@ void UamROS::updateStatus(const protocol::sensing_data::SensingDataHeader& sensi
     if (on_request_status)
     {
       status_on_request_publisher_.publish(msg);
+      publishSafetyArea(sensing_data.area_number);
       publish_status_requested_ = false;
     }
     if (on_update_status)
     {
       status_on_update_publisher_.publish(msg);
+      publishSafetyArea(sensing_data.area_number);
     }
   }
 }
 
+void UamROS::readSafetyAreas()
+{
+  // Areas already read
+  if (!safety_areas_.empty())
+    return;
+
+  ROS_INFO_STREAM("Going to read Laser Safety areas");
+
+  auto toSafetyArea = [this](const protocol::YRCommandReply& yr) -> ScanWithCRC
+  {
+    sensor_msgs::LaserScan msg;
+    msg.header.frame_id = params_.frame_id;
+    msg.angle_min = scan_params_.getAngleMinLimit();
+    msg.angle_max = scan_params_.getAngleMaxLimit();
+    msg.angle_increment = scan_params_.getAngleIncrement();
+    msg.scan_time = scan_params_.getScanPeriod();
+    msg.time_increment = scan_params_.getTimeIncrement();
+    msg.range_min = scan_params_.getRangeMin();
+    msg.range_max = scan_params_.getRangeMax();
+
+    msg.ranges.reserve(yr.area_data.size());
+    std::transform(
+      yr.area_data.begin(),
+      yr.area_data.end(),
+      std::back_inserter(msg.ranges),
+      [](const auto& range)
+      { return (range < 0x7FFF) ? static_cast<float>(range) / 1000.0f : std::numeric_limits<float>::quiet_NaN(); });
+    return std::make_pair(yr.footer.crc, msg);
+  };
+
+  decltype(safety_areas_) cached_areas;
+  for (size_t area_number = 1; area_number <= protocol::c_max_safety_area_index; area_number++)
+  {
+    for (uint16_t area_type = static_cast<uint16_t>(protocol::EYRAreaType::protection_1);
+         area_type < static_cast<uint16_t>(uam::protocol::EYRAreaType::MAX);
+         area_type++)
+    {
+      auto yr_area = lidar_.getSafetyArea(
+        static_cast<uam::protocol::EYRAreaType>(area_type),
+        area_number,
+        0,
+        uam::protocol::c_nr_ranges);
+      if (yr_area.has_value())
+      {
+        cached_areas[area_number][static_cast<uam::protocol::EYRAreaType>(area_type)] = toSafetyArea(*yr_area);
+      }
+    }
+  }
+  // We got the complete list of areas, swap
+  std::swap(cached_areas, safety_areas_);
+  ROS_INFO_STREAM("Done reading Laser Safety areas.");
+  if (params_.log_safety_areas_crc)
+  {
+    std::string area_crc_array = "";
+    for (const auto& [area_number, area] : safety_areas_)
+    {
+      for (const auto& [area_type, safety_area] : area)
+      {
+        area_crc_array += std::to_string(area_number) + "," + std::to_string(static_cast<uint16_t>(area_type)) + "," +
+                          std::to_string(safety_area.first);
+      }
+      area_crc_array += ";";
+    }
+    ROS_INFO_STREAM("Safety area CRC: " << area_crc_array);
+  }
+}
 }  // namespace uam

--- a/src/uam/uam_driver_ros_params.cpp
+++ b/src/uam/uam_driver_ros_params.cpp
@@ -75,7 +75,7 @@ UamROSParams UamROSParams::loadFromROS(const ros::NodeHandle& nh)
   nh.getParam("provide_laser_status_service", params.provide_laser_status_service);
   nh.getParam("request_status_service", params.request_status_service);
   nh.getParam("range_offset", params.range_offset);
-
+  nh.getParam("log_safety_areas_crc", params.log_safety_areas_crc);
   return params;
 }
 


### PR DESCRIPTION
* Make the params flag true in the beginning to force the same path as in reconfigure

* reverted last change and moved the set limits to the configure method

* Added debug code to viz safety areas

* Updated viz code

* Debug marker test

* Code cleanup

* PR feedback and bug on the safety area angular limitis

* Address PR feedback and add log safety area CRC