### PR TITLE
Wait for the complete scip reply

### DIFF
--- a/urg_node/include/uam/io/tcp_client.h
+++ b/urg_node/include/uam/io/tcp_client.h
@@ -168,8 +168,8 @@ public:
    *
    * @param[in] handler - Async read handler
    */
-  template <typename TReply, typename Handler>
-  void asyncReadLine(Handler handler)
+  template <typename TReply>
+  void asyncReadLine(std::function<void(const TReply&)> handler)
   {
     if (!stopped_)
     {
@@ -181,7 +181,7 @@ public:
     boost::asio::async_read_until(
       socket_,
       readline_buffer_,
-      '\n',
+      "\n\n",
       [&](const boost::system::error_code& result_error, std::size_t result_n)
       {
         if (result_error || result_n == 0)

--- a/urg_node/include/uam/protocol_types/scip_protocol_types.h
+++ b/urg_node/include/uam/protocol_types/scip_protocol_types.h
@@ -64,8 +64,6 @@ enum PPReplyLineIndex : size_t
  */
 struct PPReply
 {
-  std::string ack;
-  std::string status;
   int min_distance;
   int max_distance;
   int angular_resolution;

--- a/urg_node/include/uam/uam_driver.h
+++ b/urg_node/include/uam/uam_driver.h
@@ -168,49 +168,7 @@ public:
    *
    * @return Reply if successful received, std::nullopt otherwise
    */
-  scip_protocol::PPReply sendPPCommandWithReply(const std::chrono::duration<double>& timeout = std::chrono::seconds(2))
-  {
-    if (!client_.isConnected())
-    {
-      throw std::runtime_error("Cannot send command to lidar while disconnected.");
-    }
-
-    if (!client_.asyncSend(scip_pp_worker_.getCommand(), command_send_timeout_))
-    {
-      throw std::runtime_error("Cannot send command to lidar.");
-    }
-
-    // Prepare some state variables to be populated processCommandReply()
-    {
-      std::lock_guard<std::mutex> temp_lock(pending_command_mutex_);
-      pending_command_reply_ready_ = false;
-    }
-
-    // async read instruction with handler
-    client_.asyncReadLine<PPWorker::RawReply>(
-      [this](const PPWorker::RawReply& raw_reply)
-      {
-        auto reply = scip_pp_worker_.process(raw_reply);
-        if (reply)
-        {
-          std::lock_guard<std::mutex> lock(pending_command_mutex_);
-          // Save the reply message in a state variable and signal that it is ready
-          pending_scip_reply_ = *reply;
-          pending_command_reply_ready_ = true;
-          pending_command_signal_.notify_one();
-        }
-      });  // NOLINT
-
-    std::unique_lock<std::mutex> lock(pending_command_mutex_);
-    if (pending_command_signal_.wait_for(lock, timeout, [this] { return pending_command_reply_ready_; }))
-    {
-      return pending_scip_reply_;
-    }
-    else
-    {
-      throw std::runtime_error("Timed out waiting for scip response from the lidar.");
-    }
-  }
+  scip_protocol::PPReply sendPPCommandWithReply(const std::chrono::duration<double>& timeout = std::chrono::seconds(2));
 
   /**
    * @brief Process Command Reply and notify sender

--- a/urg_node/src/uam/uam_driver.cpp
+++ b/urg_node/src/uam/uam_driver.cpp
@@ -266,4 +266,49 @@ std::optional<protocol::YRCommandReply> UamDriver::getSafetyArea(
     adjusted_end_step);
 }
 
+
+scip_protocol::PPReply UamDriver::sendPPCommandWithReply(const std::chrono::duration<double>& timeout)
+{
+  if (!client_.isConnected())
+  {
+    throw std::runtime_error("Cannot send command to lidar while disconnected.");
+  }
+
+  if (!client_.asyncSend(scip_pp_worker_.getCommand(), command_send_timeout_))
+  {
+    throw std::runtime_error("Cannot send command to lidar.");
+  }
+
+  // Prepare some state variables to be populated processCommandReply()
+  {
+    std::lock_guard<std::mutex> temp_lock(pending_command_mutex_);
+    pending_command_reply_ready_ = false;
+  }
+
+  // async read instruction with handler
+  client_.asyncReadLine<PPWorker::RawReply>(
+    [this](const PPWorker::RawReply& raw_reply)
+    {
+      auto reply = scip_pp_worker_.process(raw_reply);
+      if (reply)
+      {
+        std::lock_guard<std::mutex> lock(pending_command_mutex_);
+        // Save the reply message in a state variable and signal that it is ready
+        pending_scip_reply_ = *reply;
+        pending_command_reply_ready_ = true;
+        pending_command_signal_.notify_one();
+      }
+    });  // NOLINT
+
+  std::unique_lock<std::mutex> lock(pending_command_mutex_);
+  if (pending_command_signal_.wait_for(lock, timeout, [this] { return pending_command_reply_ready_; }))
+  {
+    return pending_scip_reply_;
+  }
+  else
+  {
+    throw std::runtime_error("Timed out waiting for scip response from the lidar.");
+  }
+}
+
 }  // namespace uam


### PR DESCRIPTION
https://locusrobotics.atlassian.net/browse/RST-9153

The driver was failing to decode UAM's VR00 command reply (from time to time), for lidars with fw version `2.4.2r`. This was the output we would see:

```
[INFO] [/v2_20418/rear_laser_node]: Connected to: 10.66.171.9:10940
Feb 06 22:44:29 v2-20418 locus[679979]: [INFO] [/v2_20418/rear_laser_node]: Actual receive buffer size: 131072 bytes
Feb 06 22:44:29 v2-20418 locus[679979]: [INFO] [/v2_20418/rear_laser_node]: Connected to Uam lidar.
Feb 06 22:44:29 v2-20418 locus[679979]: [WARN] [/v2_20418/rear_laser_node]: Packet was received but could not make sense of it, skipping it.
Feb 06 22:44:29 v2-20418 locus[679979]: [WARN] [/v2_20418/rear_laser_node]: Packet was received but could not make sense of it, skipping it.
Feb 06 22:44:29 v2-20418 locus[679979]: [WARN] [/v2_20418/rear_laser_node]: Packet was received but could not make sense of it, skipping it.
Feb 06 22:44:29 v2-20418 locus[679979]: [WARN] [/v2_20418/rear_laser_node]: Packet was received but could not make sense of it, skipping it.
Feb 06 22:44:29 v2-20418 locus[679979]: [WARN] [/v2_20418/rear_laser_node]: Packet was received but could not make sense of it, skipping it.
Feb 06 22:44:29 v2-20418 locus[679979]: [WARN] [/v2_20418/rear_laser_node]: Packet was received but could not make sense of it, skipping it.
Feb 06 22:44:29 v2-20418 locus[679979]: [WARN] [/v2_20418/rear_laser_node]: Packet was received but could not make sense of it, skipping it.
Feb 06 22:44:29 v2-20418 locus[679979]: [WARN] [/v2_20418/rear_laser_node]: Packet was received but could not make sense of it, skipping it.
Feb 06 22:44:29 v2-20418 locus[679979]: [WARN] [/v2_20418/rear_laser_node]: Packet was received but could not make sense of it, skipping it.
Feb 06 22:44:29 v2-20418 locus[679979]: [WARN] [/v2_20418/rear_laser_node]: Packet was received but could not make sense of it, skipping it.
Feb 06 22:44:29 v2-20418 locus[679979]: [WARN] [/v2_20418/rear_laser_node]: Packet was received but could not make sense of it, skipping it.
```

After looking into it, it seems that the read buffer had 1 byte which did not belong to the `VR` reply. It turns out that the rogue byte was from the SCIP command reply we use (`PP` - get scan metadata).  That pkt, for our lidar, seems to have size 109 bytes.

It happens that lidars with `fw version 2.4.2r` split the reply into two packets, one with 108 bytes and another with 1 byte. Previous versions would only send a single pkt (109 bytes).

The solution is to wait for the packet delimiter, which for scip is (`0a 0a` - `\n\n`).

One might wonder why the single "\n" would not leave data in the read buffer as we have multiple line breakers through the `PP` reply. I think the reason is that `boost::read_until` may read beyond the delimiter. As we were receiving the complete pkt at once, we were getting bytes past the delimiter. That was not problematic as we later looked for line breaks. 

And looking into the protocol spec it is mentioned:
```
Check the two consecutive RD in the response message to confirm the response termination
```