### PR TITLE
RST-12282-nanoScan-fault-watchdog

### DIFF
--- a/urg_node_msgs/msg/Status.msg
+++ b/urg_node_msgs/msg/Status.msg
@@ -6,7 +6,7 @@ uint16 area_number
 # If the laser is reporting an error or not.
 bool error_status
 # The error code the laser is reporting.
-uint16 error_code
+uint32 error_code
 # Does the laser report that it is locked out.
 bool lockout_status
 # For the OSSD and warning states.


### PR DESCRIPTION
urg_node support for RST-12282-nanoScan-fault-watchdog. Larger error code message size needed to support the largest fault code size of 0xFFFFFFFF

Tested on locus-rst-dev floor on wrangler and bots, didn't break the bots, wrangler, or FA.

Goes along with locusrobotics/locus_bots#2369 and locusrobotics/locus_perception#596