### PR TITLE
added fix for all-nan messages on boot

### DIFF
--- a/urg_node/include/uam/uam_driver_ros.h
+++ b/urg_node/include/uam/uam_driver_ros.h
@@ -234,13 +234,14 @@ private:
       }
     }
 
-    if (finite_ranges_count == 0) {
+    if (finite_ranges_count == 0)
+    {
       // This driver/lidar combination will periodically boot up and publish all nan ranges for a moment.
-      // If this happens after a lidar power cycle (when the rest of the system is initilized), it breaks the
-      // laser filtering pipeline. The likleyhood of nominally receiving all nan readings in our usecase is so
+      // If this happens after a lidar power cycle (when the rest of the system is initialized), it breaks the
+      // laser filtering pipeline. The likelihood of nominally receiving all nan readings in our use case is so
       // infinitesimally small we can just skip publishing in this case.
-      ROS_WARN_STREAM_THROTTLE(5.0, "All ranges are infinite, skipping scan publish!");
-      // We return early to avoid publishing mis-leading scans or area information.
+      ROS_WARN_STREAM_THROTTLE(5.0, "All ranges are NaN/invalid, skipping scan publish!");
+      // We return early to avoid publishing misleading scans or area information.
       return;
     }
 

--- a/urg_node/include/uam/uam_driver_ros.h
+++ b/urg_node/include/uam/uam_driver_ros.h
@@ -204,6 +204,7 @@ private:
         nullptr;
 
     std::vector<std::pair<size_t, float>> ranges_in_safety_area;
+    size_t finite_ranges_count = 0;
 
     for (size_t idx = 0; idx < reply.ranges.size(); idx++)
     {
@@ -217,6 +218,10 @@ private:
       if (within_fov)
       {
         msg.ranges.push_back(range_m);
+        if (!std::isnan(range_m))
+        {
+          finite_ranges_count++;
+        }
       }
 
       if (safety_area != nullptr && !std::isnan(range_m))
@@ -227,6 +232,16 @@ private:
           ranges_in_safety_area.push_back(std::make_pair(idx, range_m));
         }
       }
+    }
+
+    if (finite_ranges_count == 0) {
+      // This driver/lidar combination will periodically boot up and publish all nan ranges for a moment.
+      // If this happens after a lidar power cycle (when the rest of the system is initilized), it breaks the
+      // laser filtering pipeline. The likleyhood of nominally receiving all nan readings in our usecase is so
+      // infinitesimally small we can just skip publishing in this case.
+      ROS_WARN_STREAM_THROTTLE(5.0, "All ranges are infinite, skipping scan publish!");
+      // We return early to avoid publishing mis-leading scans or area information.
+      return;
     }
 
     if constexpr (is_detected<detected_intensities, T>::value)

--- a/urg_node/include/uam/uam_driver_ros.h
+++ b/urg_node/include/uam/uam_driver_ros.h
@@ -204,7 +204,7 @@ private:
         nullptr;
 
     std::vector<std::pair<size_t, float>> ranges_in_safety_area;
-    size_t finite_ranges_count = 0;
+    bool any_finite_ranges = false;
 
     for (size_t idx = 0; idx < reply.ranges.size(); idx++)
     {
@@ -220,7 +220,7 @@ private:
         msg.ranges.push_back(range_m);
         if (!std::isnan(range_m))
         {
-          finite_ranges_count++;
+          any_finite_ranges = true;
         }
       }
 
@@ -234,7 +234,7 @@ private:
       }
     }
 
-    if (finite_ranges_count == 0)
+    if (!any_finite_ranges)
     {
       // This driver/lidar combination will periodically boot up and publish all nan ranges for a moment.
       // If this happens after a lidar power cycle (when the rest of the system is initialized), it breaks the


### PR DESCRIPTION
# Issue

This driver occasionally publishes a few all `nan` scan messages after a lidar reboot. The message is perfectly valid, and appears to the rest of the pipeline as the robot being in a 100% empty space for a brief moment. This causes the filtered scan topic to behave erratically for a few scans after a lidar power cycle (see video from the [ticket](https://locusrobotics.atlassian.net/browse/RST-15267)).

# Fix

This fix just checks if all readings are `nan` at the driver level and, if so, doesn't publish anything.

# Validation

Issue was re-produced on a bot, confirmed to not happen with this overlay.

# Notes

This raises a slightly more broad concern about how our lidar filtering pipeline handles state across lidar power-cycles, but that will be investigated [here](https://locusrobotics.atlassian.net/browse/RST-15315).