### PR TITLE
added in deadband on startup for uam driver

### DIFF
--- a/urg_node/cfg/URG.cfg
+++ b/urg_node/cfg/URG.cfg
@@ -12,7 +12,7 @@ gen.add("tf_prefix",             str_t,    0,                               "tf_
 gen.add("frame_id",              str_t,    0,                               "Output frame_id for the laserscan.",                                                                    "laser")
 gen.add("time_offset",           double_t, 0,                               "A manually calibrated offset (in seconds) to add to the timestamp before publication of a message.",    0.0,   -10.0, 10.0)
 gen.add("range_offset",          double_t, 0,                               "Adjustment, in meters, for ranges returned at all angles",                                              0.0)
-gen.add("discard_startup_data_s",double_t, 0,                               "Drop scan data for this long after each startup/reconnect, in seconds",                                 0.0,     0.0,   10.0)
+gen.add("discard_startup_data_s", double_t, 0,                               "Drop scan data for this long after each startup/reconnect, in seconds",                                 0.0,     0.0,   10.0)
 gen.add("angle_min",             double_t, 1,                               "Controls the angle of the first range measurement in radians.",                                         -pi,     -pi,   pi)
 gen.add("angle_max",             double_t, 1,                               "Controls the angle of the last range measurement in radians.",                                           pi,     -pi,   pi)
 gen.add("cluster",               int_t,    1,                               "The number of adjacent range measurements to cluster into a single reading.",                           1,         1,   99)

--- a/urg_node/cfg/URG.cfg
+++ b/urg_node/cfg/URG.cfg
@@ -12,6 +12,7 @@ gen.add("tf_prefix",             str_t,    0,                               "tf_
 gen.add("frame_id",              str_t,    0,                               "Output frame_id for the laserscan.",                                                                    "laser")
 gen.add("time_offset",           double_t, 0,                               "A manually calibrated offset (in seconds) to add to the timestamp before publication of a message.",    0.0,   -10.0, 10.0)
 gen.add("range_offset",          double_t, 0,                               "Adjustment, in meters, for ranges returned at all angles",                                              0.0)
+gen.add("discard_startup_data_s",double_t, 0,                               "Drop scan data for this long after each startup/reconnect, in seconds",                                 0.0,     0.0,   10.0)
 gen.add("angle_min",             double_t, 1,                               "Controls the angle of the first range measurement in radians.",                                         -pi,     -pi,   pi)
 gen.add("angle_max",             double_t, 1,                               "Controls the angle of the last range measurement in radians.",                                           pi,     -pi,   pi)
 gen.add("cluster",               int_t,    1,                               "The number of adjacent range measurements to cluster into a single reading.",                           1,         1,   99)

--- a/urg_node/include/uam/uam_driver_ros.h
+++ b/urg_node/include/uam/uam_driver_ros.h
@@ -418,7 +418,7 @@ private:
   ros::Time configured_stamp_;
 
   /**
-   * @brief Drop outgoing scan data until this wall time
+   * @brief Drop outgoing scan data until this ROS time
    */
   ros::Time discard_data_until_;
 

--- a/urg_node/include/uam/uam_driver_ros.h
+++ b/urg_node/include/uam/uam_driver_ros.h
@@ -141,9 +141,19 @@ private:
   template <typename T>
   void scanCallback(const T& reply, const ros::Time& wall_time)
   {
+    bool discard_scan = false;
     {
       std::lock_guard<std::mutex> lock(watchdog_mutex_);
       scan_stamp_ = ros::Time::now();
+      discard_scan = !discard_data_until_.isZero() && scan_stamp_ < discard_data_until_;
+    }
+    if (discard_scan)
+    {
+      ROS_WARN_STREAM_THROTTLE(
+        5.0,
+        "Discarding UAM scan data during startup/reconnect warmup for " << params_.discard_startup_data_s
+                                                                          << " seconds.");
+      return;
     }
     ros::Duration time_offset;
     double range_offset = 0;
@@ -409,6 +419,11 @@ private:
    * @brief The last time the lidar was configured
    */
   ros::Time configured_stamp_;
+
+  /**
+   * @brief Drop outgoing scan data until this wall time
+   */
+  ros::Time discard_data_until_;
 
   /**@}*/
 

--- a/urg_node/include/uam/uam_driver_ros.h
+++ b/urg_node/include/uam/uam_driver_ros.h
@@ -149,10 +149,7 @@ private:
     }
     if (discard_scan)
     {
-      ROS_WARN_STREAM_THROTTLE(
-        5.0,
-        "Discarding UAM scan data during startup/reconnect warmup for " << params_.discard_startup_data_s
-                                                                          << " seconds.");
+      // we already log about this somewhere else
       return;
     }
     ros::Duration time_offset;

--- a/urg_node/include/uam/uam_driver_ros_params.h
+++ b/urg_node/include/uam/uam_driver_ros_params.h
@@ -164,6 +164,11 @@ public:
   int configure_attempts { 3 };
 
   /**
+   * @brief Drop scan data for this long after each startup/reconnect, in seconds
+   */
+  double discard_startup_data_s { 0.0 };
+
+  /**
    * @brief If points are detected within this area, these will be published
    * on the points_in_safety_area topic
    */

--- a/urg_node/src/uam/uam_driver_ros.cpp
+++ b/urg_node/src/uam/uam_driver_ros.cpp
@@ -331,8 +331,7 @@ bool UamROS::configure()
     // Update laser status
     updateStatus(lidar_.getSensorStatus(), true);
 
-    // Start streaming
-    lidar_.startStreaming(params_.use_intensity, params_.use_multi_echo);
+    // Set discard deadline before starting streaming to ensure no startup packets slip through
     {
       std::lock_guard<std::mutex> lock(watchdog_mutex_);
       configured_stamp_ = ros::Time::now();
@@ -347,6 +346,9 @@ bool UamROS::configure()
         discard_data_until_ = ros::Time(0);
       }
     }
+
+    // Start streaming
+    lidar_.startStreaming(params_.use_intensity, params_.use_multi_echo);
     configure_attempts_ = 0;
     configured_ = true;
   }
@@ -385,6 +387,11 @@ bool UamROS::dynamicReconfigureCallback(urg_node::URGConfig& config, int level)
   params_.angle_min = config.angle_min;
   params_.time_offset = ros::Duration(config.time_offset);
   params_.range_offset = config.range_offset;
+  if (params_.discard_startup_data_s != config.discard_startup_data_s)
+  {
+    std::lock_guard<std::mutex> watchdog_lock(watchdog_mutex_);
+    discard_data_until_ = ros::Time::now() + ros::Duration(config.discard_startup_data_s);
+  }
   params_.discard_startup_data_s = config.discard_startup_data_s;
   params_changed_ = true;
   return true;

--- a/urg_node/src/uam/uam_driver_ros.cpp
+++ b/urg_node/src/uam/uam_driver_ros.cpp
@@ -376,6 +376,7 @@ bool UamROS::dynamicReconfigureCallback(urg_node::URGConfig& config, int level)
     config.angle_min = params_.angle_min;
     config.time_offset = params_.time_offset.toSec();
     config.range_offset = params_.range_offset;
+    config.discard_startup_data_s = params_.discard_startup_data_s;
     return true;
   }
 
@@ -384,6 +385,7 @@ bool UamROS::dynamicReconfigureCallback(urg_node::URGConfig& config, int level)
   params_.angle_min = config.angle_min;
   params_.time_offset = ros::Duration(config.time_offset);
   params_.range_offset = config.range_offset;
+  params_.discard_startup_data_s = config.discard_startup_data_s;
   params_changed_ = true;
   return true;
 }

--- a/urg_node/src/uam/uam_driver_ros.cpp
+++ b/urg_node/src/uam/uam_driver_ros.cpp
@@ -336,6 +336,16 @@ bool UamROS::configure()
     {
       std::lock_guard<std::mutex> lock(watchdog_mutex_);
       configured_stamp_ = ros::Time::now();
+      if (params_.discard_startup_data_s > 0.0)
+      {
+        discard_data_until_ = configured_stamp_ + ros::Duration(params_.discard_startup_data_s);
+        ROS_WARN_STREAM(
+          "Discarding UAM scan data for " << params_.discard_startup_data_s << " seconds after startup/reconnect.");
+      }
+      else
+      {
+        discard_data_until_ = ros::Time(0);
+      }
     }
     configure_attempts_ = 0;
     configured_ = true;

--- a/urg_node/src/uam/uam_driver_ros_params.cpp
+++ b/urg_node/src/uam/uam_driver_ros_params.cpp
@@ -76,6 +76,7 @@ UamROSParams UamROSParams::loadFromROS(const ros::NodeHandle& nh)
   nh.getParam("request_status_service", params.request_status_service);
   nh.getParam("range_offset", params.range_offset);
   nh.getParam("log_safety_areas_crc", params.log_safety_areas_crc);
+  nh.getParam("discard_startup_data_s", params.discard_startup_data_s);
 
   int reference_area;
   if (nh.getParam("reference_safety_area_type", reference_area))


### PR DESCRIPTION
prior context: https://github.com/locusrobotics/urg_node/pull/42

The previous commit ended up fixing only 1 of 2 issues. This was enough to reduce the issue incidence rate such that I thought it was a full fix. After noticing the lidar still, occasionally, produced bad data on startup I did a deep dive into the Hokuyo lidars.

I wrote a script to decipher the lidar's network traffic to see if the issue was in the lidar firmware or the driver (spoilers, it's the driver).

## Nominal boot (reconstructed from tcp packets)

Here we see the encoder count for the lidar start right off at a normal value in the first data packet sent

<img width="606" height="341" alt="image" src="https://github.com/user-attachments/assets/5d6d58b3-d77c-4eab-abe5-136d374abbff" />

And we see reasonable values for the minimum reported distance (probably some part of the robot in this case).

<img width="606" height="341" alt="image" src="https://github.com/user-attachments/assets/c3a74742-c9c0-4b65-869d-3c3cc4ab9b09" />

## Faulty boot (reconstructed from tcp packets)

But on the faulty boot, we see the encoder count start off as zero for a while

<img width="606" height="341" alt="image" src="https://github.com/user-attachments/assets/9377415e-ead9-421e-bfd3-3d0a6243643a" />

And the minimum reported distance (and reported distances in general) are all over the place until settling back down. 

<img width="606" height="341" alt="image" src="https://github.com/user-attachments/assets/896b627a-ef2b-4b5c-ba7b-1ea76452e4b1" />

Encoder count and the distances seem to be the only fields with this transient behavior. Luckily nothing on the driver end of things uses the encoder count.

## Fix

Unfortunately there is no indicator in the network packets as to when the distances will sort themselves out, so the best option is just to use a timer and throw away the first few packets from a boot/reboot.

There is an over-lap between this fix (removes orange) and the previous PR (removes red). But I believe it is valuable to have both methods active. The previous PR specifically protects us from the fully null scans, while this PR just cuts off all of the beginning data.

<img width="606" height="341" alt="image" src="https://github.com/user-attachments/assets/fe2c8bd1-35bf-49c9-b361-7f3d5484c22b" />

I have not observed this behavior on another bot yet, so I plan on keeping the default behavior off and just enabling it for this bot in FA for now.
